### PR TITLE
Updated dependency from camel 2.17.3. to  2.18.0, aligned all plugin versions to 2.18.0

### DIFF
--- a/camel-milo/pom.xml
+++ b/camel-milo/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>de.dentrassi.camel.milo</groupId>
         <artifactId>parent</artifactId>
-        <version>0.1.1-SNAPSHOT</version>
+        <version>2.18.0</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/examples/milo-example1/README.md
+++ b/examples/milo-example1/README.md
@@ -3,8 +3,8 @@ In order to use this example download and run Karaf:
     karaf> feature:repo-add mvn:org.apache.camel.karaf/apache-camel/2.18.0/xml/features
     karaf> feature:install aries-blueprint
     karaf> feature:install shell-compat camel camel-blueprint camel-paho
-    karaf> kar:install file:location/to/milo-0.1.0-SNAPSHOT.kar
-    karaf> bundle:install -s file:location/to/examples/milo-0.1.0-SNAPSHOT.jar
+    karaf> kar:install file:location/to/milo-2.18.0-SNAPSHOT.kar
+    karaf> bundle:install -s file:location/to/examples/milo-2.18.0-SNAPSHOT.jar
     
 Now the Camel route should be running and you can look at the log:
 

--- a/examples/milo-example1/pom.xml
+++ b/examples/milo-example1/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>de.dentrassi.camel.milo</groupId>
         <artifactId>parent</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>2.18.0</version>
         <relativePath>../..</relativePath>
     </parent>
 

--- a/feature/pom.xml
+++ b/feature/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>de.dentrassi.camel.milo</groupId>
         <artifactId>parent</artifactId>
-        <version>0.1.1-SNAPSHOT</version>
+        <version>2.18.0</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/feature/src/main/feature/feature.xml
+++ b/feature/src/main/feature/feature.xml
@@ -40,7 +40,7 @@
 
         <feature dependency="true">milo</feature>
 
-        <bundle dependency="true">mvn:com.google.guava/guava/18.0</bundle>
+        <bundle dependency="true">mvn:com.google.guava/guava/19.0</bundle>
         <bundle dependency="true">mvn:org.apache.camel/camel-core/${apache-camel-version}</bundle>
 
         <bundle>mvn:de.dentrassi.camel.milo/camel-milo/${project.version}</bundle>

--- a/feature/src/main/feature/feature.xml
+++ b/feature/src/main/feature/feature.xml
@@ -40,7 +40,7 @@
 
         <feature dependency="true">milo</feature>
 
-        <bundle dependency="true">mvn:com.google.guava/guava/19.0</bundle>
+        <bundle dependency="true">mvn:com.google.guava/guava/18.0</bundle>
         <bundle dependency="true">mvn:org.apache.camel/camel-core/${apache-camel-version}</bundle>
 
         <bundle>mvn:de.dentrassi.camel.milo/camel-milo/${project.version}</bundle>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>de.dentrassi.camel.milo</groupId>
     <artifactId>parent</artifactId>
-    <version>0.1.1-SNAPSHOT</version>
+    <version>2.18.0</version>
     <packaging>pom</packaging>
 
     <name>Camel :: Eclipse Milo</name>
@@ -43,8 +43,8 @@
 
     <properties>
         <eclipse-milo-version>0.1.0</eclipse-milo-version>
-        <apache-camel-version>2.17.0</apache-camel-version>
-        <apache-camel-plugin-version>2.17.3</apache-camel-plugin-version>
+        <apache-camel-version>${project.version}</apache-camel-version>
+        <apache-camel-plugin-version>${project.version}</apache-camel-plugin-version>
         <slf4j-version>1.7.0</slf4j-version>
         <logback-version>1.1.7</logback-version>
         <apache-karaf-version>4.0.0</apache-karaf-version>


### PR DESCRIPTION
As stated in #7, this plugin depends tightly on a specific camel version. It seems to be common practice for camel plugins to align with the respective camel version instead of allowing ranges. This is my attempt at integrating the camel-milo plugin into a camel 2.18.0 karaf environment.

